### PR TITLE
Python code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+*.swp
+
+# MIDAS generated files #
+#########################
+*.log
+*.sqlite

--- a/midas/modules/example.py
+++ b/midas/modules/example.py
@@ -106,13 +106,13 @@ class AnalyzePlist(object):
         value = get_plist_key(self.plist_file, key)
         if value:
             try:
-                if type(value) in [str, unicode]:
+                if isinstance(value, basestring):
                     # This should only get triggered by the Program key
                     self.data[key.lower()] = str(to_ascii(value))
                     self.data["%s_hash" % key.lower()] = hash_file(
                         str(to_ascii(value))
                     )
-                elif type(value) in [list]:
+                elif isinstance(value, (list, tuple)):
                     # This should only get triggered by the
                     # ProgramArguments key
                     self.data[key.lower()] = encode(" ".join(value))

--- a/midas/modules/example.py
+++ b/midas/modules/example.py
@@ -103,35 +103,34 @@ class AnalyzePlist(object):
         """
         Log the values of the launch agent/daemon keys in self.check_keys_hash
         """
+        key = key.lower()
+        key_hash = "%s_hash" % (key.lower(), )
+
         value = get_plist_key(self.plist_file, key)
         if value:
             try:
                 if isinstance(value, basestring):
                     # This should only get triggered by the Program key
-                    self.data[key.lower()] = str(to_ascii(value))
-                    self.data["%s_hash" % key.lower()] = hash_file(
-                        str(to_ascii(value))
-                    )
+                    self.data[key] = str(to_ascii(value))
+                    self.data[key_hash] = hash_file(str(to_ascii(value)))
                 elif isinstance(value, (list, tuple)):
                     # This should only get triggered by the
                     # ProgramArguments key
-                    self.data[key.lower()] = encode(" ".join(value))
-                    self.data["%s_hash" % key.lower()] = hash_file(
-                        str(value[0])
-                    )
+                    self.data[key] = encode(" ".join(value))
+                    self.data[key_hash] = hash_file(str(value[0]))
             except IOError:
-                self.data["%s_hash" % key.lower()] = "File DNE"
+                self.data[key_hash] = "File DNE"
         else:
-            self.data[key.lower()] = "KEY DNE"
-            self.data["%s_hash" % key.lower()] = "KEY DNE"
+            self.data[key] = "KEY DNE"
+            self.data[key_hash] = "KEY DNE"
 
     def analyze_changed_files(self):
         """
         analyze plists that have changed since last execution
         """
         where_params = self.changed_files.keys()
-        where_statement = "name=%s" % " OR name=".join(
-            ['?'] * len(where_params))
+        where_statement = "name=%s" % (" OR name=".join(
+            ['?'] * len(where_params)), )
         where_clause = [where_statement, where_params]
         self.pre_changed_files = ORM.select("plist", None, where_clause)
         for fname, fname_hash in self.changed_files.iteritems():
@@ -155,8 +154,8 @@ class AnalyzePlist(object):
         analyze new plists that are on the host
         """
         where_params = self.new_files.keys()
-        where_statement = "name=%s" % " OR name=".join(
-            ['?'] * len(where_params))
+        where_statement = "name=%s" % (" OR name=".join(
+            ['?'] * len(where_params)), )
         where_clause = [where_statement, where_params]
         self.pre_new_files = ORM.select("plist", None, where_clause)
         self.post_new_files = []
@@ -527,4 +526,4 @@ if __name__ == "__main__":
     # "--log" as a command line argument
     if "--log" in argv[1:]:
         logging.basicConfig(format='%(message)s', level=logging.INFO)
-    logging.info("Execution took %s seconds." % str(end - start))
+    logging.info("Execution took %s seconds.", str(end - start))

--- a/midas/modules/example.py
+++ b/midas/modules/example.py
@@ -22,7 +22,7 @@ from lib.tables.example import tables
 from lib.decorators import run_every_60
 
 
-class AnalyzePlist():
+class AnalyzePlist(object):
     """AnalyzePlist analyzes property list files installed on the system"""
 
     def __init__(self):
@@ -177,7 +177,7 @@ class AnalyzePlist():
             self.post_new_files.append(self.data)
 
 
-class AnalyzeKexts():
+class AnalyzeKexts(object):
     """AnalyzeKexts analyzes and aggregates currently installed kernel
     extensions"""
 
@@ -211,7 +211,7 @@ class AnalyzeKexts():
 
 
 @run_every_60
-class AnalyzeFirewallKeys():
+class AnalyzeFirewallKeys(object):
     """
     AnalyzeFirewallKeys analyzes the top level keys of com.apple.alf.plist
     """
@@ -242,7 +242,7 @@ class AnalyzeFirewallKeys():
 
 
 @run_every_60
-class AnalyzeFirewallExceptions():
+class AnalyzeFirewallExceptions(object):
     """Analyzes the systems firewall exceptions"""
 
     def __init__(self):
@@ -276,7 +276,7 @@ class AnalyzeFirewallExceptions():
 
 
 @run_every_60
-class AnalyzeFirewallExplicitauths():
+class AnalyzeFirewallExplicitauths(object):
     """Analyzes the firewall's explicit auth"""
 
     def __init__(self):
@@ -306,7 +306,7 @@ class AnalyzeFirewallExplicitauths():
 
 
 @run_every_60
-class AnalyzeFirewallProcesses():
+class AnalyzeFirewallProcesses(object):
     """Analyzes the firewalled processes in the system firewall"""
 
     def __init__(self):
@@ -349,7 +349,7 @@ class AnalyzeFirewallProcesses():
 
 
 @run_every_60
-class AnalyzeFirewallApplications():
+class AnalyzeFirewallApplications(object):
     """Analyzes firewalled application state in the systems firewall"""
 
     def __init__(self):

--- a/midas/modules/lib/config.py
+++ b/midas/modules/lib/config.py
@@ -5,66 +5,48 @@ This is the config for MIDAS
 from os.path import dirname, realpath
 
 
-class Config():
-    """the main config class"""
+config = {}
 
-    def __init__(self):
-        pass
+current_dir = dirname(realpath(__file__))
+if "/Users" in current_dir:
+    config['database'] = 'midas_hids.sqlite'
+else:
+    config['database'] = '/tmp/midas_hids.sqlite'
 
-    config = {}
+config['plist_check_keys'] = [
+    'RunAtLoad',
+    'WatchPaths',
+    'KeepAlive',
+    'StartInterval',
+    'StartOnMount',
+    'OnDemand',
+    'QueueDirectories',
+    'StandardInPath',
+    'StandardOutPath',
+    'StandardErrorPath',
+    'Debug',
+    'LaunchOnlyOnce',
+    'Sockets',
+    'OSAXHandlers',
+    'LSEnvironment',
+    'CFBundleVersion',
+]
 
-    current_dir = dirname(realpath(__file__))
-    if "/Users" in current_dir:
-        config['database'] = 'midas_hids.sqlite'
-    else:
-        config['database'] = '/tmp/midas_hids.sqlite'
+config['plist_check_keys_hash'] = [
+    'Program',
+    'ProgramArguments'
+]
 
-    config['plist_check_keys'] = [
-        'RunAtLoad',
-        'WatchPaths',
-        'KeepAlive',
-        'StartInterval',
-        'StartOnMount',
-        'OnDemand',
-        'QueueDirectories',
-        'StandardInPath',
-        'StandardOutPath',
-        'StandardErrorPath',
-        'Debug',
-        'LaunchOnlyOnce',
-        'Sockets',
-        'OSAXHandlers',
-        'LSEnvironment',
-        'CFBundleVersion',
-    ]
+config['firewall_keys'] = [
+    'allowsignedenabled',
+    'firewallunload',
+    'globalstate',
+    'loggingenabled',
+    'previousonstate',
+    'stealthenabled',
+    'version',
+]
 
-    config['plist_check_keys_hash'] = [
-        'Program',
-        'ProgramArguments'
-    ]
 
-    config['firewall_keys'] = [
-        'allowsignedenabled',
-        'firewallunload',
-        'globalstate',
-        'loggingenabled',
-        'previousonstate',
-        'stealthenabled',
-        'version',
-    ]
-
-    @staticmethod
-    def get(key, config=config):
-        """simple get method for Config class"""
-        try:
-            return config[key]
-        except KeyError:
-            return None
-
-    @staticmethod
-    def exists(key, config=config):
-        """simple exists method for Config class"""
-        if key in config.keys():
-            return True
-        else:
-            return False
+# Maintain backwards compatibility
+Config = config

--- a/midas/modules/lib/data_science.py
+++ b/midas/modules/lib/data_science.py
@@ -51,37 +51,34 @@ class DataScience():
                     new_entries.append(i)
 
         for i in new_entries:
-            master = "ty_name=\"%s\" " % self.tablename
+            master = 'ty_name="%s" ' % (self.tablename, )
             for key, value in i.iteritems():
                 if value != "KEY DNE":
-                    master += "%s=\"%s\" " % (key, value)
+                    master += '%s="%s"' % (key, value)
             self.orm.insert(self.tablename, i)
             print master
         return new_entries
 
     def __master_string(self, tablename, key):
         """master_string is an internal helper for generating a log ling"""
-        return "ty_name=\"%s\" name=\"%s\" changed_entry=\"true\"" % (
-            tablename, key
-        )
+        return 'ty_name="%s" name="%s" changed_entry="true"' % (
+            tablename, key)
 
     def __diff_string(self, changed_field, i_key, data, key, diff_string):
         """diff_string is an internal helpers for get_changed_entries"""
-        master = " %s=\"%s\" %s_old=\"%s\" %s_last_updated=\"%s\"" % (
+        master = ' %s="%s" %s_old="%s" %s_last_updated="%s"' % (
             changed_field,
             i_key,
             changed_field,
             data[key],
             changed_field,
-            data["date"],
-        )
+            data["date"],)
         if diff_string != [data[key], i_key]:
-            master += " %s_diff_added=\"%s\" %s_diff_removed=\"%s\"" % (
+            master += ' %s_diff_added="%s" %s_diff_removed="%s"' % (
                 changed_field,
                 diff_string[0],
                 changed_field,
-                diff_string[1],
-            )
+                diff_string[1],)
         return master
 
     def get_changed_entries(self):
@@ -133,11 +130,10 @@ class DataScience():
             for i in self.all_data:
                 data = self.find_in_data(self.new_data, self.key, i[self.key])
                 if not data:
-                    master = "ty_name=%s removed_entry=\"true\" " % (
-                        self.tablename,
-                    )
+                    master = 'ty_name=%s removed_entry="true" ' % (
+                        self.tablename,)
                     for key, value in i.iteritems():
                         if value != "KEY DNE" and not key.startswith("_"):
-                            master += "%s=\"%s\" " % (key, value)
+                            master += '%s="%s" ' % (key, value)
                     print master
                     self.orm.delete(i)

--- a/midas/modules/lib/helpers/filesystem.py
+++ b/midas/modules/lib/helpers/filesystem.py
@@ -409,8 +409,9 @@ def list_app_info_plist():
     info = []
     if applications:
         for app in applications:
-            if isfile('/'.join([app, "Contents/Info.plist"])):
-                info.append('/'.join([app, "Contents/Info.plist"]))
+            filename = join(app, 'Contents', 'Info.plist')
+            if isfile(filename):
+                info.append(filename)
     return info
 
 
@@ -423,8 +424,9 @@ def list_plugin_info_plist():
     info = []
     if plugins:
         for plugin in plugins:
-            if isfile('/'.join([plugin, "Contents/Info.plist"])):
-                info.append('/'.join([plugin, "Contents/Info.plist"]))
+            filename = join(plugin, 'Contents', 'Info.plist')
+            if isfile(filename):
+                info.append(filename)
     return info
 
 
@@ -433,12 +435,9 @@ def is_ssh_key(filename):
     Returns True if a file might be an ssh key, False if not
     """
     if isfile(filename) and getsizeof(filename) < 10000:
-        key = open(filename)
-        line1 = key.readline()
-        if match("^[-]*BEGIN.*PRIVATE KEY[-]*$", line1):
-            return True
-        else:
-            return False
+        with open(filename, 'rb') as key:
+            line1 = next(key)
+            return match("^[-]*BEGIN.*PRIVATE KEY[-]*$", line1) is not None
     else:
         return False
 

--- a/midas/modules/lib/helpers/filesystem.py
+++ b/midas/modules/lib/helpers/filesystem.py
@@ -144,47 +144,39 @@ def hash_kext(kextfind, kext):
     found = None
     for i in kextfind:
         if i.split('/')[-1].strip('.kext') == kext:
-            path = '/'.join([i, "Contents/MacOS/%s" % (kext, )])
+            path = join(i, "Contents", "MacOS", kext)
             if isfile(path):
                 found = path
                 break
     else:
-        path = '/'.join(
-            [
-                '/System/Library/Extensions',
-                "%s.kext" % (kext, ),
-                'Contents/MacOS',
-                kext
-            ]
-        )
+        ext_root = join('/System', 'Library', 'Extensions')
+
+        path = join(ext_root,
+                    "%s.kext" % (kext, ),
+                    'Contents', 'MacOS',
+                    kext)
+
         if isfile(path):
             return hash_file(path)
-        path = '/'.join(
-            [
-                '/System/Library/Extensions',
-                "Apple%s.kext" % (kext, ),
-                'Contents/MacOS',
-                "Apple%s" % (kext, )]
-        )
+
+        path = join(ext_root,
+                    "Apple%s.kext" % (kext, ),
+                    'Contents', 'MacOS',
+                    "Apple%s" % (kext, ))
+
         if isfile(path):
             return hash_file(path)
-        path = '/'.join(
-            [
-                '/System/Library/Extensions',
-                "%s.kext" % (kext, ),
-                kext
-            ]
-        )
+
+        path = join(ext_root, "%s.kext" % (kext, ), kext)
+
         if isfile(path):
             return hash_file(path)
-        path = '/'.join(
-            [
-                '/System/Library/Filesystems/AppleShare',
-                "%s.kext" % (kext, ),
-                'Contents/MacOS',
-                kext
-            ]
-        )
+
+        path = join('/System', 'Library', 'Filesystems', 'AppleShare',
+                     "%s.kext" % (kext, ),
+                     'Contents', 'MacOS',
+                     kext)
+
         if isfile(path):
             return hash_file(path)
 

--- a/midas/modules/lib/helpers/filesystem.py
+++ b/midas/modules/lib/helpers/filesystem.py
@@ -26,7 +26,7 @@ def list_all_in_dir(directory):
     """
     try:
         if not directory.endswith('/'):
-            directory = "%s/" % directory
+            directory = "%s/" % (directory, )
     except AttributeError:
         return []
     except OSError:
@@ -45,7 +45,7 @@ def list_files_in_dir(directory):
     """
     try:
         if not directory.endswith('/'):
-            directory = "%s/" % directory
+            directory = "%s/" % (directory, )
     except AttributeError:
         return []
     except OSError:
@@ -64,7 +64,7 @@ def list_dirs_in_dir(directory):
     """
     try:
         if not directory.endswith('/'):
-            directory = "%s/" % directory
+            directory = "%s/" % (directory, )
     except AttributeError:
         return []
     except OSError:
@@ -130,8 +130,8 @@ def get_documents():
         "numbers"
     ]
     for ext in file_extensions:
-        arg = "kMDItemDisplayName == *.%s" % ext
-        files += shell_out("mdfind %s" % arg)
+        arg = "kMDItemDisplayName == *.%s" % (ext, )
+        files += shell_out("mdfind %s" % (arg, ))
     return filter(None, files)
 
 
@@ -144,7 +144,7 @@ def hash_kext(kextfind, kext):
     found = None
     for i in kextfind:
         if i.split('/')[-1].strip('.kext') == kext:
-            path = '/'.join([i, "Contents/MacOS/%s" % kext])
+            path = '/'.join([i, "Contents/MacOS/%s" % (kext, )])
             if isfile(path):
                 found = path
                 break
@@ -152,7 +152,7 @@ def hash_kext(kextfind, kext):
         path = '/'.join(
             [
                 '/System/Library/Extensions',
-                "%s.kext" % kext,
+                "%s.kext" % (kext, ),
                 'Contents/MacOS',
                 kext
             ]
@@ -162,16 +162,16 @@ def hash_kext(kextfind, kext):
         path = '/'.join(
             [
                 '/System/Library/Extensions',
-                "Apple%s.kext" % kext,
+                "Apple%s.kext" % (kext, ),
                 'Contents/MacOS',
-                "Apple%s" % kext]
+                "Apple%s" % (kext, )]
         )
         if isfile(path):
             return hash_file(path)
         path = '/'.join(
             [
                 '/System/Library/Extensions',
-                "%s.kext" % kext,
+                "%s.kext" % (kext, ),
                 kext
             ]
         )
@@ -180,7 +180,7 @@ def hash_kext(kextfind, kext):
         path = '/'.join(
             [
                 '/System/Library/Filesystems/AppleShare',
-                "%s.kext" % kext,
+                "%s.kext" % (kext, ),
                 'Contents/MacOS',
                 kext
             ]
@@ -237,10 +237,10 @@ def find_with_perms(directory, perms):
     """
     files = []
     for [i, _, _] in walk(directory):
-        if match(r"%s" % perms, oct(stat(i)[ST_MODE])[-3:]):
+        if match(r"%s" % (perms, ), oct(stat(i)[ST_MODE])[-3:]):
             files.append(i)
         for fname in list_files_in_dir(i):
-            if match(r"%s" % perms, oct(stat(i)[ST_MODE])[-3:]):
+            if match(r"%s" % (perms, ), oct(stat(i)[ST_MODE])[-3:]):
                 files.append(fname)
     return files
 

--- a/midas/modules/lib/helpers/utilities.py
+++ b/midas/modules/lib/helpers/utilities.py
@@ -27,18 +27,18 @@ def to_ascii(value):
     """
     Returns the ascii representation of a given string
     """
-    if type(value) == str:
+    if isinstance(value, basestring):
         try:
             return value.encode("ascii", "replace")
         except UnicodeError:
             return None
         except Exception:
             return None
-    elif type(value) == dict:
+    elif isinstance(value, dict):
         try:
             temp_dict = {}
             for i, j in value.iteritems():
-                temp_dict[i] = str(j).encode("ascii", "replace")
+                temp_dict[i] = to_ascii(j)
             return temp_dict
         except UnicodeError:
             return None
@@ -59,9 +59,9 @@ def encode(string):
 
 def error_running_file(filename, section, error):
     """returns a string in log format if a module errors out"""
-    file_error = "ty_error_running_file=%s" % filename
-    section_error = "ty_error_section=%s" % section
-    error_message = "ty_error_message=\"%s\"" % repr(error)
+    file_error = "ty_error_running_file=%s" % (filename, )
+    section_error = "ty_error_section=%s" % (section, )
+    error_message = "ty_error_message=%r" % (error, )
 
     return " ".join([
         file_error,

--- a/midas/modules/lib/ty_orm.py
+++ b/midas/modules/lib/ty_orm.py
@@ -140,13 +140,13 @@ class TyORM():
             columns = []
             for result in results:
                 columns.append(result[1])
-        if type(columns) is list:
+        if isinstance(columns, (list, tuple)):
             select_columns = columns
-        elif type(columns) is str:
+        elif isinstance(column, basestring):
             columns = columns.replace(" ", "").split(",")
             select_columns = columns
 
-        if type(select_columns) is list and select_columns:
+        if isinstance(select_columns, (list, tuple)) and select_columns:
             select_columns = ', '.join(select_columns)
 
         original_columns = []
@@ -168,7 +168,7 @@ class TyORM():
 
         parameterized_attrs = None
         if where is not None:
-            if type(where) is not list:
+            if not isinstance(where, (tuple, list)):
                 sql += " WHERE %s" % where
             else:
                 sql += "WHERE %s" % where[0]
@@ -253,11 +253,11 @@ class TyORM():
         data = to_ascii(data)
         if data is None:
             return None
-        if type(data) == dict:
+        if isinstance(data, dict):
             sql = "DELETE FROM \"%s\" WHERE id = ?;" % data["_table"]
             self.raw_sql(sql, [data["_id"]])
             return
-        elif type(data) == list:
+        elif isinstance(data, (list, tuple)):
             tables_and_ids = {}
             for i in data:
                 table = i["_table"]


### PR DESCRIPTION
The following commits provide an initial cleanup effort of the code to be more Pythonic. Where possible, I've done:
- Use new style classes `class MyClass(object):` over `class MyClass:`
- Use [instance()](http://docs.python.org/2/library/functions.html#isinstance) rather than `type(object) == object2`
- Use tuples when doing string formatting, even when number of string arguments is one
- Use [os.path.join()](http://docs.python.org/2/library/os.path.html#os.path.join) whenever constructing absolute path names from strings
- Use `with open(filename) as f` syntax to ensure opened files are closed after use
- Made Config a dictionary, as it seemed unnecessary to keep it a class
- Added a couple gitignore rules to remove the log, sqlite, and vim swap files from being tracking

I've avoided making changes to plist.py, as the code is external to this project.
