### PR TITLE
data_science.py: wrap ty_name in quotes

### DIFF
--- a/midas/modules/lib/data_science.py
+++ b/midas/modules/lib/data_science.py
@@ -130,7 +130,7 @@ class DataScience():
             for i in self.all_data:
                 data = self.find_in_data(self.new_data, self.key, i[self.key])
                 if not data:
-                    master = 'ty_name=%s removed_entry="true" ' % (
+                    master = 'ty_name="%s" removed_entry="true" ' % (
                         self.tablename,)
                     for key, value in i.iteritems():
                         if value != "KEY DNE" and not key.startswith("_"):


### PR DESCRIPTION
Value of 'ty_name' parameter is missing quotes for removed entries.  Seems trivial but matters for parsing.
